### PR TITLE
Add `gum date` subcommand

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,10 @@ gum
 dist
 testdata
 
+# Demos
+*.tape
+*.gif
+
 # Folders
 completions/
 manpages/

--- a/README.md
+++ b/README.md
@@ -413,6 +413,10 @@ Or starting from an initial date of your choosing:
 gum date --value 2023-11-28
 ```
 
+![Demo of ](https://vhs.charm.sh/vhs-2Gkiemx0ALZZBmODcSrg2I.gif)
+
+<img src="https://vhs.charm.sh/vhs-2Gkiemx0ALZZBmODcSrg2I.gif" width="600" alt="Running gum date with a prompt specified" />
+
 ## Examples
 
 See the [examples](./examples/) directory for more real world use cases.

--- a/README.md
+++ b/README.md
@@ -399,6 +399,10 @@ See [`charmbracelet/log`](https://github.com/charmbracelet/log) for more usage.
 
 <img src="https://vhs.charm.sh/vhs-6jupuFM0s2fXiUrBE0I1vU.gif" width="600" alt="Running gum log with debug and error levels" />
 
+## Date
+
+<!-- TODO: add documentation here -->
+
 ## Examples
 
 See the [examples](./examples/) directory for more real world use cases.

--- a/README.md
+++ b/README.md
@@ -401,7 +401,17 @@ See [`charmbracelet/log`](https://github.com/charmbracelet/log) for more usage.
 
 ## Date
 
-<!-- TODO: add documentation here -->
+Pick a date, starting from the current date by default:
+
+```bash
+gum date
+```
+
+Or starting from an initial date of your choosing:
+
+```bash
+gum date --value 2023-11-28
+```
 
 ## Examples
 

--- a/date/command.go
+++ b/date/command.go
@@ -1,0 +1,60 @@
+package date
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/charmbracelet/gum/cursor"
+	"github.com/charmbracelet/gum/internal/exit"
+	"github.com/charmbracelet/gum/internal/stdin"
+)
+
+// Run provides a shell script interface for the text input bubble.
+// https://github.com/charmbracelet/bubbles/textinput
+func (o Options) Run() error {
+	i := textinput.New()
+	if o.Value != "" {
+		i.SetValue(o.Value)
+	} else if in, _ := stdin.Read(); in != "" {
+		i.SetValue(in)
+	}
+
+	i.Focus()
+	i.Prompt = o.Prompt
+	i.Placeholder = o.Placeholder
+	i.Width = o.Width
+	i.PromptStyle = o.PromptStyle.ToLipgloss()
+	i.Cursor.Style = o.CursorStyle.ToLipgloss()
+	i.Cursor.SetMode(cursor.Modes[o.CursorMode])
+	i.CharLimit = o.CharLimit
+
+	if o.Password {
+		i.EchoMode = textinput.EchoPassword
+		i.EchoCharacter = '•'
+	}
+
+	p := tea.NewProgram(model{
+		textinput:   i,
+		aborted:     false,
+		header:      o.Header,
+		headerStyle: o.HeaderStyle.ToLipgloss(),
+		timeout:     o.Timeout,
+		hasTimeout:  o.Timeout > 0,
+		autoWidth:   o.Width < 1,
+	}, tea.WithOutput(os.Stderr))
+	tm, err := p.Run()
+	if err != nil {
+		return fmt.Errorf("failed to run input: %w", err)
+	}
+	m := tm.(model)
+
+	if m.aborted {
+		return exit.ErrAborted
+	}
+
+	fmt.Println(m.textinput.Value())
+	return nil
+}

--- a/date/command.go
+++ b/date/command.go
@@ -13,7 +13,7 @@ import (
 // Run provides a shell script interface for the text input bubble.
 // https://github.com/charmbracelet/bubbles/textinput
 func (o Options) Run() error {
-	picker := Default()
+	picker := basePicker()
 
 	picker.prompt = o.Prompt
 	picker.promptStyle = o.PromptStyle.ToLipgloss()

--- a/date/command.go
+++ b/date/command.go
@@ -7,6 +7,7 @@ import (
 	// "github.com/charmbracelet/bubbles/textinput"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/fxtlabs/date"
 
 	// "github.com/charmbracelet/gum/cursor"
 	"github.com/charmbracelet/gum/internal/exit"
@@ -16,9 +17,14 @@ import (
 // https://github.com/charmbracelet/bubbles/textinput
 func (o Options) Run() error {
 	picker := Default()
+
 	picker.prompt = o.Prompt
 	picker.promptStyle = o.PromptStyle.ToLipgloss()
 	picker.cursorTextStyle = o.CursorTextStyle.ToLipgloss()
+
+	if initial, err := date.ParseISO(o.Value); err == nil {
+		picker.Date = initial
+	}
 
 	p := tea.NewProgram(model{
 		picker:      picker,

--- a/date/command.go
+++ b/date/command.go
@@ -4,13 +4,10 @@ import (
 	"fmt"
 	"os"
 
-	// "github.com/charmbracelet/bubbles/textinput"
-
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/fxtlabs/date"
-
-	// "github.com/charmbracelet/gum/cursor"
 	"github.com/charmbracelet/gum/internal/exit"
+
+	"github.com/fxtlabs/date"
 )
 
 // Run provides a shell script interface for the text input bubble.
@@ -21,11 +18,9 @@ func (o Options) Run() error {
 	picker.prompt = o.Prompt
 	picker.promptStyle = o.PromptStyle.ToLipgloss()
 	picker.cursorTextStyle = o.CursorTextStyle.ToLipgloss()
-
-	if initial, err := date.ParseISO(o.Value); err == nil {
-		picker.Date = initial
+	if value, err := date.ParseISO(o.Value); err == nil {
+		picker.Date = value
 	}
-
 	p := tea.NewProgram(model{
 		picker:      picker,
 		aborted:     false,

--- a/date/command.go
+++ b/date/command.go
@@ -4,46 +4,29 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/charmbracelet/bubbles/textinput"
+	// "github.com/charmbracelet/bubbles/textinput"
+
 	tea "github.com/charmbracelet/bubbletea"
 
-	"github.com/charmbracelet/gum/cursor"
+	// "github.com/charmbracelet/gum/cursor"
 	"github.com/charmbracelet/gum/internal/exit"
-	"github.com/charmbracelet/gum/internal/stdin"
 )
 
 // Run provides a shell script interface for the text input bubble.
 // https://github.com/charmbracelet/bubbles/textinput
 func (o Options) Run() error {
-	i := textinput.New()
-	if o.Value != "" {
-		i.SetValue(o.Value)
-	} else if in, _ := stdin.Read(); in != "" {
-		i.SetValue(in)
-	}
-
-	i.Focus()
-	i.Prompt = o.Prompt
-	i.Placeholder = o.Placeholder
-	i.Width = o.Width
-	i.PromptStyle = o.PromptStyle.ToLipgloss()
-	i.Cursor.Style = o.CursorStyle.ToLipgloss()
-	i.Cursor.SetMode(cursor.Modes[o.CursorMode])
-	i.CharLimit = o.CharLimit
-
-	if o.Password {
-		i.EchoMode = textinput.EchoPassword
-		i.EchoCharacter = '•'
-	}
+	picker := Default()
+	picker.prompt = o.Prompt
+	picker.promptStyle = o.PromptStyle.ToLipgloss()
+	picker.cursorTextStyle = o.CursorTextStyle.ToLipgloss()
 
 	p := tea.NewProgram(model{
-		textinput:   i,
+		picker:      picker,
 		aborted:     false,
 		header:      o.Header,
 		headerStyle: o.HeaderStyle.ToLipgloss(),
 		timeout:     o.Timeout,
 		hasTimeout:  o.Timeout > 0,
-		autoWidth:   o.Width < 1,
 	}, tea.WithOutput(os.Stderr))
 	tm, err := p.Run()
 	if err != nil {
@@ -55,6 +38,6 @@ func (o Options) Run() error {
 		return exit.ErrAborted
 	}
 
-	fmt.Println(m.textinput.Value())
+	fmt.Println(m.picker.Value())
 	return nil
 }

--- a/date/date.go
+++ b/date/date.go
@@ -1,11 +1,9 @@
-// FIXME: replace this docstring.
-// Package input provides a shell script interface for the text input bubble.
-// https://github.com/charmbracelet/bubbles/tree/master/textinput
+// Package date provides a shell script interface for picking a date.
 //
-// It can be used to prompt the user for some input. The text the user entered
-// will be sent to stdout.
+// The date the user selected will be sent to stdout in ISO-8601 format:
+// YYYY-MM-DD.
 //
-// $ gum input --placeholder "What's your favorite gum?" > answer.text
+// $ gum date --value 2023-11-28 > date.text
 package date
 
 import (

--- a/date/date.go
+++ b/date/date.go
@@ -1,0 +1,78 @@
+// FIXME: replace this docstring.
+// Package input provides a shell script interface for the text input bubble.
+// https://github.com/charmbracelet/bubbles/tree/master/textinput
+//
+// It can be used to prompt the user for some input. The text the user entered
+// will be sent to stdout.
+//
+// $ gum input --placeholder "What's your favorite gum?" > answer.text
+package date
+
+import (
+	"time"
+
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/gum/timeout"
+	"github.com/charmbracelet/lipgloss"
+)
+
+type model struct {
+	autoWidth   bool
+	header      string
+	headerStyle lipgloss.Style
+	textinput   textinput.Model
+	quitting    bool
+	aborted     bool
+	timeout     time.Duration
+	hasTimeout  bool
+}
+
+func (m model) Init() tea.Cmd {
+	return tea.Batch(
+		textinput.Blink,
+		timeout.Init(m.timeout, nil),
+	)
+}
+func (m model) View() string {
+	if m.quitting {
+		return ""
+	}
+	if m.header != "" {
+		header := m.headerStyle.Render(m.header)
+		return lipgloss.JoinVertical(lipgloss.Left, header, m.textinput.View())
+	}
+
+	return m.textinput.View()
+}
+
+func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case timeout.TickTimeoutMsg:
+		if msg.TimeoutValue <= 0 {
+			m.quitting = true
+			m.aborted = true
+			return m, tea.Quit
+		}
+		m.timeout = msg.TimeoutValue
+		return m, timeout.Tick(msg.TimeoutValue, msg.Data)
+	case tea.WindowSizeMsg:
+		if m.autoWidth {
+			m.textinput.Width = msg.Width - lipgloss.Width(m.textinput.Prompt) - 1
+		}
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "ctrl+c", "esc":
+			m.quitting = true
+			m.aborted = true
+			return m, tea.Quit
+		case "enter":
+			m.quitting = true
+			return m, tea.Quit
+		}
+	}
+
+	var cmd tea.Cmd
+	m.textinput, cmd = m.textinput.Update(msg)
+	return m, cmd
+}

--- a/date/date.go
+++ b/date/date.go
@@ -11,17 +11,15 @@ package date
 import (
 	"time"
 
-	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/gum/timeout"
 	"github.com/charmbracelet/lipgloss"
 )
 
 type model struct {
-	autoWidth   bool
 	header      string
 	headerStyle lipgloss.Style
-	textinput   textinput.Model
+	picker      *picker
 	quitting    bool
 	aborted     bool
 	timeout     time.Duration
@@ -30,20 +28,20 @@ type model struct {
 
 func (m model) Init() tea.Cmd {
 	return tea.Batch(
-		textinput.Blink,
 		timeout.Init(m.timeout, nil),
 	)
 }
+
 func (m model) View() string {
 	if m.quitting {
 		return ""
 	}
 	if m.header != "" {
 		header := m.headerStyle.Render(m.header)
-		return lipgloss.JoinVertical(lipgloss.Left, header, m.textinput.View())
+		return lipgloss.JoinVertical(lipgloss.Left, header, m.picker.View())
 	}
 
-	return m.textinput.View()
+	return m.picker.View()
 }
 
 func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
@@ -56,10 +54,10 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.timeout = msg.TimeoutValue
 		return m, timeout.Tick(msg.TimeoutValue, msg.Data)
-	case tea.WindowSizeMsg:
-		if m.autoWidth {
-			m.textinput.Width = msg.Width - lipgloss.Width(m.textinput.Prompt) - 1
-		}
+	// case tea.WindowSizeMsg:
+	// 	if m.autoWidth {
+	// 		m.textinput.Width = msg.Width - lipgloss.Width(m.textinput.Prompt) - 1
+	// 	}
 	case tea.KeyMsg:
 		switch msg.String() {
 		case "ctrl+c", "esc":
@@ -73,6 +71,6 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	}
 
 	var cmd tea.Cmd
-	m.textinput, cmd = m.textinput.Update(msg)
+	m.picker, cmd = m.picker.Update(msg)
 	return m, cmd
 }

--- a/date/options.go
+++ b/date/options.go
@@ -7,12 +7,12 @@ import (
 )
 
 // Options are the customization options for the date.
+// TODO: make output format configurable.
 type Options struct {
-	Placeholder     string        `help:"Placeholder value" default:"Type something..." env:"GUM_DATE_PLACEHOLDER"`
 	Prompt          string        `help:"Prompt to display" default:"> " env:"GUM_DATE_PROMPT"`
 	PromptStyle     style.Styles  `embed:"" prefix:"prompt." envprefix:"GUM_DATE_PROMPT_"`
 	CursorTextStyle style.Styles  `embed:"" prefix:"cursor." set:"defaultForeground=212" set:"defaultUnderline=true" envprefix:"GUM_DATE_CURSOR_"`
-	Value           string        `help:"Initial value (can also be passed via stdin)" default:""`
+	Value           string        `help:"Initial value in ISO 8601 format, e.g. 2023-11-28" default:""`
 	Header          string        `help:"Header value" default:"" env:"GUM_DATE_HEADER"`
 	HeaderStyle     style.Styles  `embed:"" prefix:"header." set:"defaultForeground=240" envprefix:"GUM_DATE_HEADER_"`
 	Timeout         time.Duration `help:"Timeout until input aborts" default:"0" env:"GUM_DATE_TIMEOUT"`

--- a/date/options.go
+++ b/date/options.go
@@ -8,6 +8,7 @@ import (
 
 // Options are the customization options for the date.
 // TODO: make output format configurable.
+// TODO: allow specifying an offset for the initial date in days.
 type Options struct {
 	Prompt          string        `help:"Prompt to display" default:"> " env:"GUM_DATE_PROMPT"`
 	PromptStyle     style.Styles  `embed:"" prefix:"prompt." envprefix:"GUM_DATE_PROMPT_"`

--- a/date/options.go
+++ b/date/options.go
@@ -10,7 +10,7 @@ import (
 type Options struct {
 	Prompt          string        `help:"Prompt to display" default:"> " env:"GUM_DATE_PROMPT"`
 	PromptStyle     style.Styles  `embed:"" prefix:"prompt." envprefix:"GUM_DATE_PROMPT_"`
-	CursorTextStyle style.Styles  `embed:"" prefix:"cursor." set:"defaultForeground=212" set:"defaultUnderline=true" envprefix:"GUM_DATE_CURSOR_"`
+	CursorTextStyle style.Styles  `embed:"" prefix:"cursor." set:"defaultForeground=212" set:"defaultUnderline=true" envprefix:"GUM_DATE_CURSOR_"` //nolint:staticcheck
 	Value           string        `help:"Initial value in ISO 8601 format, e.g. 2023-11-28" default:""`
 	Header          string        `help:"Header value" default:"" env:"GUM_DATE_HEADER"`
 	HeaderStyle     style.Styles  `embed:"" prefix:"header." set:"defaultForeground=240" envprefix:"GUM_DATE_HEADER_"`

--- a/date/options.go
+++ b/date/options.go
@@ -6,18 +6,14 @@ import (
 	"github.com/charmbracelet/gum/style"
 )
 
-// Options are the customization options for the input.
+// Options are the customization options for the date.
 type Options struct {
-	Placeholder string        `help:"Placeholder value" default:"Type something..." env:"GUM_INPUT_PLACEHOLDER"`
-	Prompt      string        `help:"Prompt to display" default:"> " env:"GUM_INPUT_PROMPT"`
-	PromptStyle style.Styles  `embed:"" prefix:"prompt." envprefix:"GUM_INPUT_PROMPT_"`
-	CursorStyle style.Styles  `embed:"" prefix:"cursor." set:"defaultForeground=212" envprefix:"GUM_INPUT_CURSOR_"`
-	CursorMode  string        `prefix:"cursor." name:"mode" help:"Cursor mode" default:"blink" enum:"blink,hide,static" env:"GUM_INPUT_CURSOR_MODE"`
-	Value       string        `help:"Initial value (can also be passed via stdin)" default:""`
-	CharLimit   int           `help:"Maximum value length (0 for no limit)" default:"400"`
-	Width       int           `help:"Input width (0 for terminal width)" default:"40" env:"GUM_INPUT_WIDTH"`
-	Password    bool          `help:"Mask input characters" default:"false"`
-	Header      string        `help:"Header value" default:"" env:"GUM_INPUT_HEADER"`
-	HeaderStyle style.Styles  `embed:"" prefix:"header." set:"defaultForeground=240" envprefix:"GUM_INPUT_HEADER_"`
-	Timeout     time.Duration `help:"Timeout until input aborts" default:"0" env:"GUM_INPUT_TIMEOUT"`
+	Placeholder     string        `help:"Placeholder value" default:"Type something..." env:"GUM_DATE_PLACEHOLDER"`
+	Prompt          string        `help:"Prompt to display" default:"> " env:"GUM_DATE_PROMPT"`
+	PromptStyle     style.Styles  `embed:"" prefix:"prompt." envprefix:"GUM_DATE_PROMPT_"`
+	CursorTextStyle style.Styles  `embed:"" prefix:"cursor." set:"defaultForeground=212" envprefix:"GUM_DATE_CURSOR_"`
+	Value           string        `help:"Initial value (can also be passed via stdin)" default:""`
+	Header          string        `help:"Header value" default:"" env:"GUM_DATE_HEADER"`
+	HeaderStyle     style.Styles  `embed:"" prefix:"header." set:"defaultForeground=240" envprefix:"GUM_DATE_HEADER_"`
+	Timeout         time.Duration `help:"Timeout until input aborts" default:"0" env:"GUM_DATE_TIMEOUT"`
 }

--- a/date/options.go
+++ b/date/options.go
@@ -7,8 +7,6 @@ import (
 )
 
 // Options are the customization options for the date.
-// TODO: make output format configurable.
-// TODO: allow specifying an offset for the initial date in days.
 type Options struct {
 	Prompt          string        `help:"Prompt to display" default:"> " env:"GUM_DATE_PROMPT"`
 	PromptStyle     style.Styles  `embed:"" prefix:"prompt." envprefix:"GUM_DATE_PROMPT_"`

--- a/date/options.go
+++ b/date/options.go
@@ -11,7 +11,7 @@ type Options struct {
 	Placeholder     string        `help:"Placeholder value" default:"Type something..." env:"GUM_DATE_PLACEHOLDER"`
 	Prompt          string        `help:"Prompt to display" default:"> " env:"GUM_DATE_PROMPT"`
 	PromptStyle     style.Styles  `embed:"" prefix:"prompt." envprefix:"GUM_DATE_PROMPT_"`
-	CursorTextStyle style.Styles  `embed:"" prefix:"cursor." set:"defaultForeground=212" envprefix:"GUM_DATE_CURSOR_"`
+	CursorTextStyle style.Styles  `embed:"" prefix:"cursor." set:"defaultForeground=212" set:"defaultUnderline=true" envprefix:"GUM_DATE_CURSOR_"`
 	Value           string        `help:"Initial value (can also be passed via stdin)" default:""`
 	Header          string        `help:"Header value" default:"" env:"GUM_DATE_HEADER"`
 	HeaderStyle     style.Styles  `embed:"" prefix:"header." set:"defaultForeground=240" envprefix:"GUM_DATE_HEADER_"`

--- a/date/options.go
+++ b/date/options.go
@@ -1,0 +1,23 @@
+package date
+
+import (
+	"time"
+
+	"github.com/charmbracelet/gum/style"
+)
+
+// Options are the customization options for the input.
+type Options struct {
+	Placeholder string        `help:"Placeholder value" default:"Type something..." env:"GUM_INPUT_PLACEHOLDER"`
+	Prompt      string        `help:"Prompt to display" default:"> " env:"GUM_INPUT_PROMPT"`
+	PromptStyle style.Styles  `embed:"" prefix:"prompt." envprefix:"GUM_INPUT_PROMPT_"`
+	CursorStyle style.Styles  `embed:"" prefix:"cursor." set:"defaultForeground=212" envprefix:"GUM_INPUT_CURSOR_"`
+	CursorMode  string        `prefix:"cursor." name:"mode" help:"Cursor mode" default:"blink" enum:"blink,hide,static" env:"GUM_INPUT_CURSOR_MODE"`
+	Value       string        `help:"Initial value (can also be passed via stdin)" default:""`
+	CharLimit   int           `help:"Maximum value length (0 for no limit)" default:"400"`
+	Width       int           `help:"Input width (0 for terminal width)" default:"40" env:"GUM_INPUT_WIDTH"`
+	Password    bool          `help:"Mask input characters" default:"false"`
+	Header      string        `help:"Header value" default:"" env:"GUM_INPUT_HEADER"`
+	HeaderStyle style.Styles  `embed:"" prefix:"header." set:"defaultForeground=240" envprefix:"GUM_INPUT_HEADER_"`
+	Timeout     time.Duration `help:"Timeout until input aborts" default:"0" env:"GUM_INPUT_TIMEOUT"`
+}

--- a/date/picker.go
+++ b/date/picker.go
@@ -25,11 +25,11 @@ const (
 
 // incr i in direction d; bodge mod-3 indexing.
 func (i interval) incr(d direction) interval {
-	if mod := (int(i) + int(d)) % 3; mod < 0 {
+	mod := (int(i) + int(d)) % 3
+	if mod < 0 {
 		return year
-	} else {
-		return interval(mod)
 	}
+	return interval(mod)
 }
 
 type direction int
@@ -50,7 +50,7 @@ type picker struct {
 	cursorTextStyle lipgloss.Style
 }
 
-func Default() *picker {
+func basePicker() *picker {
 	return &picker{
 		Date:            date.Today(),
 		focus:           day,

--- a/date/picker.go
+++ b/date/picker.go
@@ -2,6 +2,7 @@ package date
 
 import (
 	"strings"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -57,7 +58,28 @@ func (p *picker) formatDate() string {
 	raw := p.Date.Format("02 Jan 2006")
 	parts := strings.Split(raw, " ")
 	parts[int(p.focus)] = p.cursorTextStyle.Render(parts[int(p.focus)])
-	return strings.Join(parts, " ")
+	return strings.Join(parts, " ") + " " + p.formatWeekday()
+}
+
+func (p *picker) formatWeekday() string {
+	name := ""
+	switch p.Date.Weekday() {
+	case time.Monday:
+		name = "Mon"
+	case time.Tuesday:
+		name = "Tue"
+	case time.Wednesday:
+		name = "Wed"
+	case time.Thursday:
+		name = "Thu"
+	case time.Friday:
+		name = "Fri"
+	case time.Saturday:
+		name = "Sat"
+	case time.Sunday:
+		name = "Sun"
+	}
+	return lipgloss.NewStyle().Faint(true).Render(name)
 }
 
 func (p *picker) incr(d direction) {

--- a/date/picker.go
+++ b/date/picker.go
@@ -1,0 +1,110 @@
+package date
+
+import (
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/fxtlabs/date"
+)
+
+type interval int
+
+const (
+	day   interval = 0
+	month interval = 1
+	year  interval = 2
+)
+
+// incr i in direction d; bodge mod-3 indexing.
+func (i interval) incr(d direction) interval {
+	if mod := (int(i) + int(d)) % 3; mod < 0 {
+		return year
+	} else {
+		return interval(mod)
+	}
+}
+
+type direction int
+
+const (
+	forward  direction = 1
+	backward direction = -1
+)
+
+// picker implements tea.Model for a date.Date.
+type picker struct {
+	date.Date
+	focus interval
+
+	promptStyle lipgloss.Style
+	prompt      string
+
+	cursorTextStyle lipgloss.Style
+}
+
+func Default() *picker {
+	return &picker{
+		Date:   date.Today(),
+		focus:  day,
+		prompt: "> ",
+		// TODO: reconsider these styles; look at reference.
+		cursorTextStyle: lipgloss.NewStyle().Underline(true).Foreground(lipgloss.Color("201")),
+	}
+}
+
+func (p *picker) formatDate() string {
+	raw := p.Date.Format("02 Jan 2006")
+	parts := strings.Split(raw, " ")
+	parts[int(p.focus)] = p.cursorTextStyle.Render(parts[int(p.focus)])
+	return strings.Join(parts, " ")
+}
+
+func (p *picker) incr(d direction) {
+	switch p.focus {
+	case day:
+		p.Date = p.Date.AddDate(0, 0, int(d))
+	case month:
+		p.Date = p.Date.AddDate(0, int(d), 0)
+	case year:
+		p.Date = p.Date.AddDate(int(d), 0, 0)
+	}
+}
+
+// Init implements tea.Model.
+func (p *picker) Init() tea.Cmd {
+	return nil
+}
+
+// Update implements tea.Model.
+func (p *picker) Update(msg tea.Msg) (*picker, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		// "up"/"down" increment/decrement the focused component, respectively
+		case "up", "k":
+			p.incr(forward)
+		case "down", "j":
+			p.incr(backward)
+
+		// "left"/"right" cycle the focused component
+		case "left", "h":
+			p.focus = p.focus.incr(backward)
+		case "right", "l":
+			p.focus = p.focus.incr(forward)
+		}
+
+		// TODO: add support for typing digits
+	}
+	return p, nil
+}
+
+// View implements tea.Model.
+func (p *picker) View() string {
+	return p.promptStyle.Render(p.prompt) + p.formatDate()
+}
+
+// Value of p.
+func (p *picker) Value() date.Date {
+	return p.Date
+}

--- a/date/picker.go
+++ b/date/picker.go
@@ -120,8 +120,6 @@ func (p *picker) Update(msg tea.Msg) (*picker, tea.Cmd) {
 		case "right", "l":
 			p.focus = p.focus.incr(forward)
 		}
-
-		// TODO: add support for typing digits
 	}
 	return p, nil
 }

--- a/date/picker.go
+++ b/date/picker.go
@@ -11,6 +11,12 @@ import (
 
 type interval int
 
+// Default styles.
+var (
+	weekdayStyle           = lipgloss.NewStyle().Faint(true)
+	defaultCursorTextStyle = lipgloss.NewStyle().Underline(true).Foreground(lipgloss.Color("201"))
+)
+
 const (
 	day   interval = 0
 	month interval = 1
@@ -46,11 +52,10 @@ type picker struct {
 
 func Default() *picker {
 	return &picker{
-		Date:   date.Today(),
-		focus:  day,
-		prompt: "> ",
-		// TODO: reconsider these styles; look at reference.
-		cursorTextStyle: lipgloss.NewStyle().Underline(true).Foreground(lipgloss.Color("201")),
+		Date:            date.Today(),
+		focus:           day,
+		prompt:          "> ",
+		cursorTextStyle: defaultCursorTextStyle,
 	}
 }
 
@@ -79,7 +84,7 @@ func (p *picker) formatWeekday() string {
 	case time.Sunday:
 		name = "Sun"
 	}
-	return lipgloss.NewStyle().Faint(true).Render(name)
+	return weekdayStyle.Render(name)
 }
 
 func (p *picker) incr(d direction) {

--- a/examples/test.sh
+++ b/examples/test.sh
@@ -10,6 +10,10 @@ gum choose Unlimited Choice Of Items --no-limit --cursor "* " --cursor-prefix "(
 gum confirm "Testing?"
 gum confirm "No?" --default=false --affirmative "Okay." --negative "Cancel."
 
+# Date
+gum date
+gum date --value 2021-10-10
+
 # Filter
 gum filter
 echo {1..500} | sed 's/ /\n/g' | gum filter

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/containerd/console v1.0.4-0.20230313162750-1ae8d489ac81 // indirect
 	github.com/dlclark/regexp2 v1.8.1 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
+	github.com/fxtlabs/date v0.0.0-20150819233934-d9ab6e2a88a9 // indirect
 	github.com/go-logfmt/logfmt v0.6.0 // indirect
 	github.com/gorilla/css v1.0.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -29,6 +29,8 @@ github.com/dlclark/regexp2 v1.8.1 h1:6Lcdwya6GjPUNsBct8Lg/yRPwMhABj269AAzdGSiR+0
 github.com/dlclark/regexp2 v1.8.1/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
+github.com/fxtlabs/date v0.0.0-20150819233934-d9ab6e2a88a9 h1:NERIc41aohgojUAgWCCnN5B8dIXZsBo2UC04LR3tbao=
+github.com/fxtlabs/date v0.0.0-20150819233934-d9ab6e2a88a9/go.mod h1:UoIEyXCyEJ1Zu3ejiUOSngl9U5Oe9S+qaNiYiUex2nk=
 github.com/go-logfmt/logfmt v0.6.0 h1:wGYYu3uicYdqXVgoYbvnkrPVXkuLM1p1ifugDMEdRi4=
 github.com/go-logfmt/logfmt v0.6.0/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
 github.com/gorilla/css v1.0.0 h1:BQqNyPTi50JCFMTw/b67hByjMVXZRwGha6wxVGkeihY=

--- a/gum.go
+++ b/gum.go
@@ -59,7 +59,15 @@ type Gum struct {
 	//
 	Confirm confirm.Options `cmd:"" help:"Ask a user to confirm an action"`
 
-	// FIXME: add docstring here.
+	// Date provides an interface for picking a date. Outputs the selected date
+	// in ISO 8601 format: `YYYY-MM-DD`.
+	//
+	// $ gum date
+	//
+	// You can specify a start date in ISO 8601 format. Let's pick a date
+	// starting with the initial value Nov. 28, 2023:
+	//
+	// $ gum date --value="2023-11-28"
 	Date date.Options `cmd:"" help:"Pick a date"`
 
 	// File provides an interface to pick a file from a folder (tree).

--- a/gum.go
+++ b/gum.go
@@ -6,6 +6,7 @@ import (
 	"github.com/charmbracelet/gum/choose"
 	"github.com/charmbracelet/gum/completion"
 	"github.com/charmbracelet/gum/confirm"
+	"github.com/charmbracelet/gum/date"
 	"github.com/charmbracelet/gum/file"
 	"github.com/charmbracelet/gum/filter"
 	"github.com/charmbracelet/gum/format"
@@ -57,6 +58,9 @@ type Gum struct {
 	// $ gum confirm "Are you sure?" && rm file.txt
 	//
 	Confirm confirm.Options `cmd:"" help:"Ask a user to confirm an action"`
+
+	// FIXME: add docstring here.
+	Date date.Options `cmd:"" help:"Pick a date"`
 
 	// File provides an interface to pick a file from a folder (tree).
 	// The user is provided a file manager-like interface to navigate, to


### PR DESCRIPTION
Fixes https://github.com/charmbracelet/gum/discussions/409.

You may also be happy with `date +%F`.

See also https://github.com/charmbracelet/bubbles/pull/76, a more visually complicated date-picker. If that `bubbles` component gets merged, `gum date` should use it (or offer a flag to use it).

### Changes
- Adds a `gum date` subcommand. Supports:
  - Specified `--prompt`, `--header`, and corresponding styles (clone of `gum input`).
  - Specified starting date `--value` in ISO 8601 format.
- Ignores [`charmbracelet/vhs`](https://github.com/charmbracelet/vhs) precursors and gifs.
